### PR TITLE
feature/tensor_matrix_vector

### DIFF
--- a/docs/cpputil.puml
+++ b/docs/cpputil.puml
@@ -15,6 +15,8 @@ namespace cpputil {
         bool **areEqualEigenvalues**(const Eigen::VectorXd& eigenvalues1, const Eigen::VectorXd& eigenvalues2, double tolerance)
         bool **areEqualEigenvectors**(const Eigen::VectorXd& eigenvectors1, const Eigen::VectorXd& eigenvectors2, double tolerance)
         bool **areEqualSetsOfEigenvectors**(const Eigen::MatrixXd& eigenvectors1, const Eigen::MatrixXd& eigenvectors2, double tolerance)
+
+        Eigen::MatrixXd **toMatrix**(const Eigen::Tensor<double, 4>& T)
     }
 
     class cpputil {

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -54,6 +54,19 @@ bool areEqualSetsOfEigenvectors(const Eigen::MatrixXd& eigenvectors1, const Eige
                                 double tolerance);
 
 
+/**
+ *  Reduce a rank-4 tensor @param T to and @return a 2-dimensional matrix
+ *
+ *  The elements of the tensor @param T are found the matrix such that
+ *      M(m,n) = T(i,j,k,l)
+ *
+ *  in which
+ *      m is calculated from i and j in a column-major way
+ *      n is calculated from k and l in a column-major way
+ */
+Eigen::MatrixXd toMatrix(const Eigen::Tensor<double, 4>& T);
+
+
 }  // namespace linalg
 }  // namespace cpputil
 

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -107,5 +107,40 @@ bool areEqualSetsOfEigenvectors(const Eigen::MatrixXd& eigenvectors1, const Eige
 }
 
 
+/**
+ *  Reduce a rank-4 tensor @param T to and @return a 2-dimensional matrix
+ *
+ *  The elements of the tensor @param T are found the matrix such that
+ *      M(m,n) = T(i,j,k,l)
+ *
+ *  in which
+ *      m is calculated from i and j in a column-major way
+ *      n is calculated from k and l in a column-major way
+ */
+Eigen::MatrixXd toMatrix(const Eigen::Tensor<double, 4>& T) {
+
+    // Initialize the resulting matrix
+    const auto& dims = T.dimensions();
+    Eigen::MatrixXd M (dims[0]*dims[1], dims[2]*dims[3]);
+
+
+    // Calculate the compound indices and bring the elements from the tensor over into the matrix
+    for (size_t i = 0; i < dims[0]; i++) {
+        for (size_t j = 0; j < dims[1]; j++) {
+            for (size_t k = 0; k < dims[2]; k++) {
+                for (size_t l = 0; l < dims[3]; l++) {
+                    size_t m = i + dims[0] * j;
+                    size_t n = k + dims[2] * l;
+
+                    M(m,n) = T(i,j,k,l);
+                }
+            }
+        }
+    }
+
+    return M;
+}
+
+
 }  // namespace linalg
 }  // namespace cpputil

--- a/tests/linalg_test.cpp
+++ b/tests/linalg_test.cpp
@@ -113,3 +113,30 @@ BOOST_AUTO_TEST_CASE ( areEqualSetsOfEigenvectors_example ) {
 
     BOOST_CHECK(!cpputil::linalg::areEqualSetsOfEigenvectors(eigenvectors1, eigenvectors4, 1.0e-6));
 }
+
+
+BOOST_AUTO_TEST_CASE ( toMatrix ) {
+
+    // Create an example tensor
+    Eigen::Tensor<double, 4> T (2, 2, 2, 2);
+
+    for (size_t i = 0; i < 2; i++) {
+        for (size_t j = 0; j < 2; j++) {
+            for (size_t k = 0; k < 2; k++) {
+                for (size_t l = 0; l < 2; l++) {
+                    T(i,j,k,l) = l + 2*k + 4*j + 8*i;
+                }
+            }
+        }
+    }
+
+
+    Eigen::MatrixXd M_ref (4, 4);
+    M_ref <<  0,  2,  1,  3,
+              8, 10,  9, 11,
+              4,  6,  5,  7,
+             12, 14, 13, 15;
+
+
+    BOOST_CHECK(M_ref.isApprox(cpputil::linalg::toMatrix(T), 1.0e-12));
+}


### PR DESCRIPTION
For the implementation of OO-DOCI with gradient and Hessian, we need a way to convert the generalized Fock matrix to a vector (the gradient) and the super generalized Fock matrix (which is a rank-4 tensor) to a matrix.

The gradient part can easily be done using `Eigen::Map<Eigen::VectorXd>`.

Reshaping the tensor to the correct rank (rank-4 to rank-2) can probably be done using `Eigen::Tensor`, but the documentation on their `.reshape()` function is so outdated that I can't even compile their example.